### PR TITLE
Added img type to 2 imgs. Fixed css so square images still rounded.

### DIFF
--- a/website/css/index.css
+++ b/website/css/index.css
@@ -695,6 +695,7 @@ body {
   height: 100%;
   background-color: rgba(200,200,200,1);
   border-radius: 10px;
+  overflow: hidden;
 }
 
 #spotlight > .spotlight-picture > .spotlight-img > iframe {

--- a/website/js/spotlight_data.js
+++ b/website/js/spotlight_data.js
@@ -167,7 +167,7 @@ Non-Profits in 2018.
     },
     {
         "imgs": [
-          new StoryMedia('./img/montoya.jpg')
+          new StoryMedia('./img/montoya.jpg', '', landscape)
         ],
         "desc":
         `
@@ -182,7 +182,7 @@ will take place in Kuala Lumpur (Malaysia), followed by San Francisco in the fol
     },
     {
         "imgs": [
-          new StoryMedia('./img/broderick.png')
+          new StoryMedia('./img/broderick.png', '', portrait)
         ],
         "desc":
         `


### PR DESCRIPTION
Image type (portrait, landscape) were not included in two most recent spotlight images added. Additionally, When images were squares, they would have square corners because they'd fill the container div exactly. Adding overflow hidden makes it so that square images (n * n pixels) are rounded even when no gray overflow background is present.