### PR TITLE
resized dots to fit mainstream phones. fixed last story desc.

### DIFF
--- a/website/css/index.css
+++ b/website/css/index.css
@@ -782,7 +782,7 @@ body {
 }
 
 
-@media (max-width: 460px) {
+@media (max-width: 768px) {
   .dot {
     width: 20px;
     height: 20px;

--- a/website/css/index.css
+++ b/website/css/index.css
@@ -781,6 +781,20 @@ body {
   cursor: pointer;
 }
 
+
+@media (max-width: 460px) {
+  .dot {
+    width: 20px;
+    height: 20px;
+    margin: 0 2px;
+  }
+
+  .arrow {
+    width: 15px;
+    height: 15px;
+  }
+}
+
 .left-picture {
   left: 0;
   border-radius: 3px 0 0 3px;

--- a/website/js/spotlight_data.js
+++ b/website/js/spotlight_data.js
@@ -186,9 +186,8 @@ will take place in Kuala Lumpur (Malaysia), followed by San Francisco in the fol
         ],
         "desc":
         `
-Kelsey Broderick supports the Asia practice's work on a wide variety of issues and countries, with a particular 
-emphasis on China at Eurasia Group. Kelsey currently works at Eurasia Group, where she is an analyst in the Asia team 
-with a particular focus on Chinese foreign policy and Taiwan. You might see Kelsey discussing Chinese politics on Bloomberg News.
+Kelsey Broderick currently works at the Eurasia Group, where she is an analyst in the Asia team with a particular focus 
+on Chinese foreign policy and Taiwan. You might see Kelsey discussing Chinese politics on Bloomberg News (search her).
 <br>
 <br>
 Prior to Eurasia Group, she researched macroeconomic trends in China at the World Bank and held internships at the 


### PR DESCRIPTION
with 10 stories, dots overflow into 2 rows, so I changed the size with a media query. It still does not scale well to even smaller than phone screens because I just used px again, but I thought it better to just make sure it works for most phones (tested on chrome) rather than edit the JS to dynamically size dots.